### PR TITLE
Cleanup + MLM support

### DIFF
--- a/OptGroup.php
+++ b/OptGroup.php
@@ -71,6 +71,15 @@ class OptGroup extends \ExternalModules\AbstractExternalModule {
                             console.warn("Optgroup value '" + groupValue + "' for field '" + fieldName + "' is missing from dropdown choices.");
                         }
                     });
+                    if (select.classList.contains('rc-autocomplete')) {
+                        // When autocomplete is enabled, the action tag will break down. To preserve the intent, we simply remove all options marked as group labels
+                        options.forEach(function(option) {
+                            if (groupValues.includes(option.value)) {
+                                $(option).remove();
+                            }
+                        });
+                        return; // Done
+                    }
                     options.forEach(function(option) {
                         if (groupValues.includes(option.value)) {
                             currentOptGroup = document.createElement("optgroup");

--- a/OptGroup.php
+++ b/OptGroup.php
@@ -44,8 +44,10 @@ class OptGroup extends \ExternalModules\AbstractExternalModule {
             document.addEventListener("DOMContentLoaded", function () {
                 var optgroupMetadata = <?=json_encode($optgroupFields)?>;
                 if (!optgroupMetadata) return;
-                if (<?=$this->getJavascriptModuleObjectName()?>.isMlmActive()) {
-                    <?=$this->getJavascriptModuleObjectName()?>.afterRender(function() {
+                var JSMO = <?=$this->getJavascriptModuleObjectName()?>;
+                var mlmActive = JSMO.isMlmActive();
+                if (mlmActive) {
+                    JSMO.afterRender(function() {
                         // Need to update optgroup label
                         document.querySelectorAll("[mlm-optgroup-label]").forEach(function(option) {
                             var optgroup = option.parentNode;
@@ -73,11 +75,13 @@ class OptGroup extends \ExternalModules\AbstractExternalModule {
                         if (groupValues.includes(option.value)) {
                             currentOptGroup = document.createElement("optgroup");
                             currentOptGroup.label = option.textContent.trim();
-                            // Hide the original option but add it so that MLM can translate it, and add a marker
-                            option.style.display = "none";
-                            option.setAttribute("mlm-optgroup-label", "1");
-                            option.setAttribute("disabled", "disabled");
-                            currentOptGroup.appendChild(option);
+                            if (mlmActive) {
+                                // Hide the original option but add it so that MLM can translate it, and add a marker
+                                option.style.display = "none";
+                                option.setAttribute("mlm-optgroup-label", "1");
+                                option.setAttribute("disabled", "disabled");
+                                currentOptGroup.appendChild(option);
+                            }
                             fragment.appendChild(currentOptGroup);
                             return;
                         }

--- a/OptGroup.php
+++ b/OptGroup.php
@@ -74,6 +74,7 @@ class OptGroup extends \ExternalModules\AbstractExternalModule {
                     options.forEach(function(option) {
                         if (groupValues.includes(option.value)) {
                             currentOptGroup = document.createElement("optgroup");
+                            currentOptGroup.setAttribute("choice", option.value);
                             currentOptGroup.label = option.textContent.trim();
                             if (mlmActive) {
                                 // Hide the original option but add it so that MLM can translate it, and add a marker


### PR DESCRIPTION
This adds MLM support. It does so by leaving the original options intact, but hidden, and then hooks into the afterRender callback to update the optgroup labels from the original options (which will be updated by MLM).

Feel free to add me as co-author (or not).

If you do:
```
        {
            "name": "Günther Rezniczek",
            "email": "guenther.rezniczek@rub.de",
            "institution": "Marien Hospital Herne - Klinikum der Ruhr-Universität Bochum"
        }
```